### PR TITLE
add line numerotation + fix quotes error in html

### DIFF
--- a/assets/bin.css
+++ b/assets/bin.css
@@ -24,8 +24,25 @@ body {
 	background-color: #23241f;
 	resize: none;
 	color: inherit;
-	overflow: auto;
 	font-family: inherit;
 	line-height: inherit;
 	overflow: scroll;
+}
+
+#hlcode {
+	line-height:2px;
+}
+
+#hlcode li {
+	list-style-type:decimal-leading-zero; /* decimal : 9, 10 | decimal-leading-zero : 09, 10 */
+	list-style-position: inside;
+}
+
+#hlcode li::before { /* separate line counter of code ( 1.      print("hi") )*/
+	content:"";
+	margin-right:1%;
+}
+
+#hlcode li::marker {
+	color:#B0BEC5; /* list-style-type color */
 }

--- a/bin.html
+++ b/bin.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<title>bin</title>
-	<meta charset=utf-8>
+	<meta charset="utf-8">
 	%if code:
 	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/styles/monokai-sublime.min.css">
 	<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.3.1/highlight.min.js"></script>
@@ -15,15 +15,19 @@
 </head>
 <body>
 	%if code:
-	<div id=newbin>
-		<select id=select></select>
+	<div id="newbin">
+		<select id="select"></select>
 		<a href="/"><button>New bin</button></a>
 	</div>
-	<pre><code id=hlcode class="lang-{{lang}}">{{code}}</code></pre>
+	<pre><code id="hlcode" class="lang-{{lang}}">
+% for line in code:
+<li>{{line}}</li>
+% end
+</code></pre>
 	%else:
-	<form action="/" method=POST>
-		<textarea name=code id=code placeholder="bin something." autofocus></textarea>
-		<input type=submit id=submit hidden>
+	<form action="/" method="POST">
+		<textarea name="code" id="code" placeholder="bin something." autofocus></textarea>
+		<input type="submit" id="submit" hidden>
 	</form>
 	%end
 </body>

--- a/bin.py
+++ b/bin.py
@@ -50,8 +50,12 @@ def bin(hexhash, lang=None):
     lang = (request.query.get('lang') or ext).lower()
     lang = lang_aliases.get(lang, lang) or "plaintext"
     code = database.get(hexhash)
+
     if not code:
         raise HTTPError(status=404)
+    
+    code = code.split("\n")
+        
     return template(html, code=code, lang=lang)
 
 


### PR DESCRIPTION
- Add paste line numerotation on `bin` route -> `bin` template.
- Fix quotes error in html. By example : 
```html
<meta charset=utf-8>
```